### PR TITLE
Push docker hub image to maplarge org repo

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Get image repositories
         run: |
-          echo DOCKER_IMAGE_REPOSITORY=$(echo ${{ vars.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
+          echo DOCKER_IMAGE_REPOSITORY=$(echo maplarge/${{ github.event.repository.name }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
           echo GHCR_IMAGE_REPOSITORY=$(echo ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
 
       - name: Get the release

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ RUN pip3 install /maplarge/ml_python_packages/maplargeclient
 # MapLarge mounts the docker volume to /tmp/config but unless
 # permissions are declared here, it will be mounted as root and
 # this container will be unable to write to it
-RUN mkdir -p /tmp/config && chgrp -R 0 /tmp/config && \
+RUN mkdir -p /tmp/config && \
+  chgrp -R 0 /tmp/config && \
   chmod -R g=u /tmp/config && \
   chmod a+x /maplarge/entrypoint.sh && \
   chgrp -R 0 /maplarge && \

--- a/maplarge/entrypoint.sh
+++ b/maplarge/entrypoint.sh
@@ -13,10 +13,6 @@ mkdir -p /maplarge/config
 
 cp $connection_file /maplarge/config/connection.json
 
-cp $connection_file /tmp/config/connection.json
-# Modify the connection file to use proper IP address now
-# sed -i 's;127.0.0.1;0.0.0.0;' ${connection_file}
-
 python3 -m ipykernel_launcher --ip=0.0.0.0 -f /maplarge/config/connection.json --InteractiveShellApp.exec_lines="from maplargeclient import *; import maplarge; maplarge.Start();" &
 pid=$!
 


### PR DESCRIPTION
Currently the image gets pushed to the docker  user's repo, but should go to the org